### PR TITLE
add username to profile page; remove name textfield from edit box

### DIFF
--- a/client/src/pages/Profile/Profile.js
+++ b/client/src/pages/Profile/Profile.js
@@ -41,6 +41,7 @@ const useStyles = makeStyles((theme) => ({
 function Profile(props) {
   const [state, setState] = useState({
     name: "",
+    username: "",
     biography: "",
     userLinks: "",
     profilePic: "",
@@ -54,6 +55,7 @@ function Profile(props) {
         // console.log(res.data)
 
         let dataName = res.data.firstName + " " + res.data.lastName;
+        let dataUsername = res.data.username;
         let dataBiography = res.data.biography;
         let dataUserLinks = res.data.userLinks;
         let dataProfilePic = res.data.profilePic;
@@ -61,6 +63,7 @@ function Profile(props) {
         setState({
           ...state,
           name: dataName,
+          username: dataUsername,
           biography: dataBiography,
           userLinks: dataUserLinks,
           profilePic: dataProfilePic,
@@ -121,8 +124,12 @@ function Profile(props) {
         <Grid xs={12}>
           <Grid item direction="row">
             <Typography gutterBottom variant="h3" component="h2">
-              {state.name}
+              {state.username}
             </Typography>
+            <Typography gutterBottom variant="h6" component="h2">
+              ({state.name})
+            </Typography>
+
             <h3>Bio</h3>
             <Typography variant="body2" color="textSecondary" component="p">
               {state.biography}
@@ -177,17 +184,6 @@ function Profile(props) {
             value={state.profilePic}
             alt={state.name}
             src={state.profilePic}
-          />
-          <TextField
-            onChange={handleEdit}
-            name="name"
-            value={state.name}
-            autoFocus
-            margin="dense"
-            id="name"
-            label="Name"
-            type="name"
-            fullWidth
           />
           <TextField
             onChange={handleEdit}


### PR DESCRIPTION
-- add user's username to profile page
-- remove "name" textfield from edit dialogue box
     -- i did this because when a user edits the name in this field, it doesn't actually change the name stored in the database, meaning when a user refreshes/logs in later, their name will revert back to what it was before
     -- if we want to allow the user to change their name, we'll have to write the code so that they can change their first and last name separately and have that store in the database, not just in state