### PR TITLE
make a temp fix for the colorwall modal; some minor changes

### DIFF
--- a/client/src/components/TempDrawer.js
+++ b/client/src/components/TempDrawer.js
@@ -87,13 +87,13 @@ export default function TemporaryDrawer(props) {
               <ListItemIcon>
                 <VpnKeyIcon />
               </ListItemIcon>
-              <ListItemText primary="Login" />
+              <ListItemText primary="Log In" />
             </ListItem>
             <ListItem button component={Link} to="/signup">
               <ListItemIcon>
                 <CreateIcon />
               </ListItemIcon>
-              <ListItemText primary="Signup" />
+              <ListItemText primary="Sign Up" />
             </ListItem>
           </>
         )}

--- a/client/src/pages/ColorWall.js
+++ b/client/src/pages/ColorWall.js
@@ -81,19 +81,18 @@ function ColorWall() {
   // ===========================================
   // FOR THE MODAL/DIALOG BOX:
   // ===========================================
-  const [selectedValue, setSelectedValue] = useState(displayedPosts);
   const [open, setOpen] = useState(false);
   const [openedPost, setOpenedPost] = useState({});
 
   const handleClickOpen = (value) => {
-    setOpen(true);
-    setSelectedValue(value.target.src);
     setOpenedPost(posts.find((post) => post.imageUrl === value.target.src));
+    if (openedPost.User !== undefined) {
+      setOpen(true);
+    }
   };
 
-  const handleClose = (value) => {
+  const handleClose = () => {
     setOpen(false);
-    setSelectedValue(value);
     setOpenedPost({});
   };
 
@@ -119,58 +118,68 @@ function ColorWall() {
               ></img>
             </div>
           ))}
-            <Dialog
-              onClose={handleClose}
-              aria-labelledby="simple-dialog-title"
-              open={open}
-              selectedValue={selectedValue}
-            >
-              <Card className={classes.root}>
-                <CardHeader
-                  avatar={
-                    <Avatar aria-label="user" className={classes.avatar}>
-                      <a
-                        className={classes.userPageLink}
-                        href={openedPost.postLink}
-                  ></a>
-                    </Avatar>
-                  }
-                  title={openedPost.title}
-                />
-                <CardMedia
-                  className={classes.media}
-                  image={openedPost.imageUrl}
-                />
-                <CardContent>
-                  <Typography
-                    variant="body2"
-                    color="textSecondary"
-                    component="p"
-                  >
-                    {openedPost.description}
-                  </Typography>
-                  <hr></hr>
-                  <Typography
-                    variant="body2"
-                    color="textSecondary"
-                    component="p"
-                  >
-                    <a target="__blank" href={openedPost.postLink}>
-                      {openedPost.postLink}
+          <Dialog
+            onClose={handleClose}
+            aria-labelledby="simple-dialog-title"
+            open={open}
+          >
+            <Card className={classes.root}>
+              <CardHeader
+                avatar={
+                  <Avatar aria-label="user" className={classes.avatar}>
+                    <a
+                      className={classes.userPageLink}
+                      href={
+                        openedPost.User !== undefined
+                          ? `/users/${openedPost.User.id}`
+                          : ""
+                      }
+                    >
+                      {openedPost.User !== undefined
+                        ? `${openedPost.User.firstName.charAt(
+                            0
+                          )}${openedPost.User.lastName.charAt(0)}`
+                        : ""}
                     </a>
-                  </Typography>
-                </CardContent>
-                <CardActions disableSpacing>
-                  <IconButton
-                    onClick={() => addLike(openedPost)}
-                    aria-label="Add like"
-                  >
-                    <FavoriteIcon />
-                    <>{openedPost.userLikes}</>
-                  </IconButton>
-                </CardActions>
-              </Card>
-            </Dialog>
+                  </Avatar>
+                }
+                title={openedPost.title}
+              />
+              <CardMedia
+                className={classes.media}
+                image={openedPost.imageUrl}
+              />
+              <CardContent>
+                <Typography variant="body2" color="textSecondary" component="p">
+                  {openedPost.description}
+                </Typography>
+                <hr></hr>
+                <Typography variant="body2" color="textSecondary" component="p">
+                  <span>website: </span>
+                  <a target="__blank" href={openedPost.postLink}>
+                    {openedPost.postLink}
+                  </a>
+                </Typography>
+                <Typography variant="body2" color="textSecondary" component="p">
+                  <span>
+                    price:{" "}
+                    <span style={{ fontWeight: "bold" }}>
+                      ${openedPost.price}
+                    </span>
+                  </span>
+                </Typography>
+              </CardContent>
+              <CardActions disableSpacing>
+                <IconButton
+                  onClick={() => addLike(openedPost)}
+                  aria-label="Add like"
+                >
+                  <FavoriteIcon style={{ color: "red" }} />
+                  <>{openedPost.userLikes}</>
+                </IconButton>
+              </CardActions>
+            </Card>
+          </Dialog>
         </section>
       </div>
     </>

--- a/client/src/pages/Profile/Profile.js
+++ b/client/src/pages/Profile/Profile.js
@@ -5,8 +5,7 @@ import {
   makeStyles,
   Fab,
   Grid,
-  Typography,
-  CardContent,
+  Typography
 } from "@material-ui/core";
 import Button from "@material-ui/core/Button";
 import AddIcon from "@material-ui/icons/Add";
@@ -44,6 +43,7 @@ function Profile(props) {
     username: "",
     biography: "",
     userLinks: "",
+    email: "",
     profilePic: "",
   });
 
@@ -58,6 +58,7 @@ function Profile(props) {
         let dataUsername = res.data.username;
         let dataBiography = res.data.biography;
         let dataUserLinks = res.data.userLinks;
+        let dataEmail = res.data.email;
         let dataProfilePic = res.data.profilePic;
 
         setState({
@@ -66,6 +67,7 @@ function Profile(props) {
           username: dataUsername,
           biography: dataBiography,
           userLinks: dataUserLinks,
+          email: dataEmail,
           profilePic: dataProfilePic,
         });
       })
@@ -138,6 +140,12 @@ function Profile(props) {
             <Typography>
               <a target="__blank" href={state.userLinks}>
                 {state.userLinks}
+              </a>
+            </Typography>
+            <h3>Email</h3>
+            <Typography>
+              <a href={`mailto:${state.email}`}>
+                {state.email}
               </a>
             </Typography>
           </Grid>


### PR DESCRIPTION
-- ColorWall has a **TEMPORARY** solution that allows the card to display info from both the Post and User models
     -- there seems to be an async issue; a better solution would be nicer, because the current one causes the user to have to click an image **TWICE** to see the modal pop up
-- in the modal, clicking the icon with the post user's initials (upper left corner) will take you to that user's Color-Story profile (at the **"/users/(id)"** route) ... this public user profile needs to be made
-- added email address to the Profile page; clicking it allows you to send an email to the user ("mailto:")
-- some minor fixes to the TempDrawer