### PR TITLE
Navbar text centered

### DIFF
--- a/client/src/components/Navigation/style.css
+++ b/client/src/components/Navigation/style.css
@@ -6,4 +6,8 @@
   .MuiGrid-grid-xs-12 .makeStyles-bar-2 .MuiToolbar-gutters {
     padding-left: 0px;
   }
+
+}
+.makeStyles-bar-2 {
+  align-items: center;
 }


### PR DESCRIPTION
Centered 'color story' text in navbar. (Menu icon is also centered, needs to be moved to left, I'll work on it)