### PR TITLE
Menu Icon Fix

### DIFF
--- a/client/src/components/Navigation/TempDrawer.js
+++ b/client/src/components/Navigation/TempDrawer.js
@@ -26,7 +26,7 @@ const useStyles = makeStyles((theme) => ({
   font: {
     fontSize: "50px",
     [theme.breakpoints.down("sm")]: {
-      fontSize: "30px",
+      fontSize: "20px",
     }
   },
 }));


### PR DESCRIPTION
Changed mobile breakpoint size so icon doesn't overlap text in navbar on any size screen