### PR TITLE
fix colorwall modal like button

### DIFF
--- a/client/src/components/ColorWall/ColorWallModal.js
+++ b/client/src/components/ColorWall/ColorWallModal.js
@@ -202,24 +202,28 @@ function ColorWallModal(props) {
         </CardContent>
         <br></br>
         {user !== undefined ? (
-          <CardActions disableSpacing>
-            <IconButton onClick={() => addLike()} aria-label="Add like">
-              <FavoriteIcon style={{ color: "red" }} />
-            </IconButton>
-          </CardActions>
+          user.email ? (
+            <CardActions disableSpacing>
+              <IconButton onClick={() => addLike()} aria-label="Add like">
+                <FavoriteIcon style={{ color: "red" }} />
+              </IconButton>
+            </CardActions>
+          ) : (
+            <>
+              <Typography
+                variant="body2"
+                color="textSecondary"
+                component={Link}
+                to="/signup"
+                className={classes.modalSignupBtn}
+              >
+                <span>sign up or log in to like this post</span>
+              </Typography>
+              <br></br>
+            </>
+          )
         ) : (
-          <>
-            <Typography
-              variant="body2"
-              color="textSecondary"
-              component={Link}
-              to="/signup"
-              className={classes.modalSignupBtn}
-            >
-              <span>sign up or log in to like this post</span>
-            </Typography>
-            <br></br>
-          </>
+          <></>
         )}
       </Card>
     </Dialog>

--- a/client/src/pages/ColorWall.js
+++ b/client/src/pages/ColorWall.js
@@ -2,7 +2,6 @@ import React, { useState, useEffect } from "react";
 import { makeStyles } from "@material-ui/core/styles";
 import ButtonRow from "../components/ColorWall/ButtonRow";
 import API from "../utils/API";
-import NoPostsComment from "../components/ColorWall/NoPostsComment";
 import ColorWallModal from "../components/ColorWall/ColorWallModal";
 
 const useStyles = makeStyles({


### PR DESCRIPTION
-- ColorWall modal "like" button is only supposed to render if the user is logged in. There was a bug making the heart icon always show up, though the functionality remained as we wanted. This has been fixed so that if the user is not logged in, they see a button linking to the signup page instead. 
-- no more error when user tries to go to "/users/:id" anymore