### PR TITLE
make modal avatar larger; move items around a little

### DIFF
--- a/client/src/components/ColorWall/ColorWallModal.js
+++ b/client/src/components/ColorWall/ColorWallModal.js
@@ -13,15 +13,16 @@ import FavoriteIcon from "@material-ui/icons/Favorite";
 
 const useStyles = makeStyles((theme) => ({
   root: {
-   
     paddingBottom: "15px",
     overflow: "auto",
     "& .MuiPaper-rounded": {
       borderRadius: "24px",
-      boxShadow: "10px 10px 5px 0px rgba(0,0,0,0.75);"
-    }
+      boxShadow: "10px 10px 5px 0px rgba(0,0,0,0.75);",
+    },
   },
   avatar: {
+    height: "80px",
+    width: "80px",
     border: "2px solid white",
     "&:hover": {
       border: "2px solid pink",
@@ -35,7 +36,9 @@ const useStyles = makeStyles((theme) => ({
     },
   },
   cardDescription: {
-    padding: "2% 10% 2% 2%",
+    [theme.breakpoints.down("xs")]: {
+      paddingRight: "10px",
+    },
   },
   modalUsernameLink: {
     fontSize: "15px",
@@ -83,15 +86,13 @@ function ColorWallModal(props) {
   const handleClose = props.handleClose;
   const addLike = props.addLike;
   const classes = useStyles();
-  
-  
+
   return (
     <Dialog
       onClose={handleClose}
       aria-labelledby="simple-dialog-title"
       open={open}
       className={classes.root}
-      
     >
       <Card className={classes.root}>
         <CardHeader
@@ -119,6 +120,29 @@ function ColorWallModal(props) {
           }
           title={openedPost.title}
         />
+        <Typography
+          variant="body2"
+          color="textSecondary"
+          component="h4"
+          style={{ margin: "-15px 10px 10px 15px" }}
+        >
+          posted by{" "}
+          {openedPost.User !== undefined ? (
+            <Typography
+              className={classes.modalUsernameLink}
+              component={Link}
+              to={
+                openedPost.User !== undefined
+                  ? `/users/${openedPost.User.id}`
+                  : ""
+              }
+            >
+              {openedPost.User !== undefined ? openedPost.User.username : ""}
+            </Typography>
+          ) : (
+            <div></div>
+          )}
+        </Typography>
         <img
           style={{ width: "100%" }}
           src={
@@ -130,29 +154,6 @@ function ColorWallModal(props) {
         ></img>
         <CardContent>
           <Typography variant="body2" color="textSecondary" component="h4">
-            posted by{" "}
-            {openedPost.User !== undefined ? (
-              <Typography
-                className={classes.modalUsernameLink}
-                component={Link}
-                to={
-                  openedPost.User !== undefined
-                    ? `/users/${openedPost.User.id}`
-                    : ""
-                }
-              >
-                {openedPost.User !== undefined ? openedPost.User.username : ""}
-              </Typography>
-            ) : (
-              <div></div>
-            )}
-          </Typography>
-          <Typography
-            variant="body2"
-            color="textSecondary"
-            component="h4"
-            style={{ marginTop: "10px" }}
-          >
             posted on{" "}
             {openedPost.createdAt !== undefined ? (
               <span>

--- a/client/src/components/ColorWall/ColorWallModal.js
+++ b/client/src/components/ColorWall/ColorWallModal.js
@@ -13,6 +13,7 @@ import FavoriteIcon from "@material-ui/icons/Favorite";
 
 const useStyles = makeStyles((theme) => ({
   root: {
+    minWidth: 345,
     paddingBottom: "15px",
     overflow: "auto",
     "& .MuiPaper-rounded": {

--- a/client/src/components/ColorWall/ColorWallModal.js
+++ b/client/src/components/ColorWall/ColorWallModal.js
@@ -13,7 +13,7 @@ import FavoriteIcon from "@material-ui/icons/Favorite";
 
 const useStyles = makeStyles((theme) => ({
   root: {
-    minWidth: 345,
+    minWidth: 300,
     paddingBottom: "15px",
     overflow: "auto",
     "& .MuiPaper-rounded": {

--- a/client/src/components/ColorWall/ColorWallModal.js
+++ b/client/src/components/ColorWall/ColorWallModal.js
@@ -28,6 +28,10 @@ const useStyles = makeStyles((theme) => ({
       border: "2px solid pink",
     },
   },
+  title: {
+    fontWeight: "bold",
+    fontSize: "25px",
+  },
   modalInitialsLogo: {
     textDecoration: "none",
     color: "white",
@@ -118,7 +122,7 @@ function ColorWallModal(props) {
               }
             ></Avatar>
           }
-          title={openedPost.title}
+          title={<Typography className={classes.title}>{openedPost.title}</Typography>}
         />
         <Typography
           variant="body2"

--- a/client/src/pages/ColorWall.js
+++ b/client/src/pages/ColorWall.js
@@ -57,7 +57,7 @@ function ColorWall(props) {
         setPosts(result.data);
       });
     }
-  }, []);
+  }, [props.userId]);
 
   const filteredPosts = posts.filter((post) => post.colorCategory === color);
   let displayedPosts = color ? filteredPosts : posts;

--- a/client/src/pages/Favorite.js
+++ b/client/src/pages/Favorite.js
@@ -3,7 +3,7 @@ import { makeStyles } from "@material-ui/core/styles";
 import API from "../utils/API";
 import { Link } from "react-router-dom";
 
-const useStyles = makeStyles({
+const useStyles = makeStyles((theme) => ({
   imageSection: {
     width: "100%",
   },
@@ -15,6 +15,11 @@ const useStyles = makeStyles({
     MozColumnGap: "0px",
     columnCount: 3,
     columnGap: "0px",
+    [theme.breakpoints.down("xs")]: {
+      WebkitColumnCount: 1,
+      MozColumnCount: 1,
+      columnCount: 1,
+    },
   },
   imgStyle: {
     width: "100%",
@@ -23,7 +28,7 @@ const useStyles = makeStyles({
       opacity: "0.5",
     },
   },
-});
+}));
 
 function Favorite(props) {
   // const user = props.user;


### PR DESCRIPTION
-- make modal avatar image larger
-- move post author to card header
-- set a minWidth for the modal size; this is in case someone posts a really small image. this way, the rest of the text on the modal won't have formatting issues
-- edit breakpoints
-- make modal title text font size larger
-- fix PublicProfile.js colorwall image results; it now only gets that user's posts, instead of all of them